### PR TITLE
Fixed vertical positioning for Info and Settings columns when adding many components

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -10,7 +10,7 @@ img.gearIcon {
   height: 40px;
   margin-right: 10px;
 }
-h1.setup-app{
+h1.setup-app {
   display: flex;
 }
 
@@ -43,12 +43,10 @@ h1.setup-app{
 }
 
 .App .InfoPane .container-info {
-  height: 90%;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
   -ms-flex-pack: distribute;
-  justify-content: space-around;
   -webkit-box-orient: vertical;
   -webkit-box-direction: normal;
   -ms-flex-direction: column;

--- a/src/index.css
+++ b/src/index.css
@@ -46,7 +46,6 @@ h1.setup-app {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
-  -ms-flex-pack: distribute;
   -webkit-box-orient: vertical;
   -webkit-box-direction: normal;
   -ms-flex-direction: column;
@@ -146,12 +145,9 @@ h1.setup-app {
 }
 
 .App .SettingsPane .container-settings {
-  height: 90%;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
-  -ms-flex-pack: distribute;
-  justify-content: space-around;
   -webkit-box-orient: vertical;
   -webkit-box-direction: normal;
   -ms-flex-direction: column;
@@ -188,7 +184,7 @@ h1.setup-app {
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin: 10px 0;
+  margin: 16px 0px;
 }
 
 .App .SettingsPane .SettingsHead {


### PR DESCRIPTION
1. Removed flexbox height and justify-content property in **.container-settings** and **.container-info** for more consistent UI.

2. Clicking the add button used to decrease the whitespace between form-containers, ultimately changing the button position. Doesn't happen anymore. Added extra 6px vertical padding to form-containers.

Here's a screenshot of the new look:
![react-builder screenshot](https://user-images.githubusercontent.com/51155558/94874237-26934a00-046f-11eb-9901-883b5c7c5497.png)

This is my 2nd PR for hacktoberfest2020. Hope you like these changes.
Fixes #13 